### PR TITLE
Fix crash on enum name override

### DIFF
--- a/constantsgen/constantsparse.py
+++ b/constantsgen/constantsparse.py
@@ -128,6 +128,9 @@ class ConstantsParser:
                     value = 0
                     if explicit_values:
                         name = explicit_values[0][0]
+                        if name in enum_definition.name_overrides:
+                            name = enum_definition.name_overrides[name]
+
                         value = int(enum_values[name], base=0) + 1
 
                     for name in implicit_values:


### PR DESCRIPTION
When a explicitly assigned value was renamed and followed by implicit
values, the starting value was not looked up correctly.

Signed-off-by: Joshua Kahn <jkahn@barracuda.com>